### PR TITLE
Remove upper bound for sentry-ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
   push:
     branches: [ main ]
-  schedule:
-    - cron: '5 4 * * *'
 
 jobs:
   lint:
@@ -30,7 +28,7 @@ jobs:
       matrix:
         ruby: ['3.2', '3.3', '3.4' ]
         sentry: ['~> 5.25', 'latest']
-        stoplight: ["~> 4.1", "~> 5", "latest"]
+        stoplight: ["~> 5", "latest"]
     env:
       SENTRY_VERSION: ${{ matrix.sentry }}
       STOPLIGHT_VERSION: ${{ matrix.stoplight }}

--- a/Gemfile
+++ b/Gemfile
@@ -19,9 +19,8 @@ else
   gem "sentry-ruby", sentry_version
 end
 
-
 stoplight_version = ENV.fetch("STOPLIGHT_VERSION", "latest")
-if sentry_version == "latest"
+if stoplight_version == "latest"
   gem "stoplight"
 else
   gem "stoplight", stoplight_version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     stoplight-sentry (0.2.0)
       sentry-ruby (>= 5)
-      stoplight
+      stoplight (>= 5)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     stoplight-sentry (0.2.0)
-      sentry-ruby (>= 5, < 6.0)
-      stoplight (>= 4.0)
+      sentry-ruby (>= 5)
+      stoplight
 
 GEM
   remote: https://rubygems.org/

--- a/lib/stoplight/sentry/notifier.rb
+++ b/lib/stoplight/sentry/notifier.rb
@@ -25,7 +25,7 @@ module Stoplight
       # @param options [Hash] custom options for the +Sentry#capture_message+ method
       def initialize(sentry, formatter = nil, **options)
         @sentry = sentry
-        @formatter = formatter || Stoplight::Default::FORMATTER
+        @formatter = formatter || Stoplight::Wiring::Default::FORMATTER
         @options = options
       end
 

--- a/lib/stoplight/sentry/notifier.rb
+++ b/lib/stoplight/sentry/notifier.rb
@@ -20,12 +20,19 @@ module Stoplight
       #   @return [Hash]
       attr_reader :options
 
+      DEFAULT_FORMATTER = lambda do |light, from_color, to_color, error|
+        words = ["Switching", light.name, "from", from_color, "to", to_color]
+        words += ["because", error.class, error.message] if error
+        words.join(" ")
+      end
+      private_constant :DEFAULT_FORMATTER
+
       # @param sentry [::Sentry]
-      # @param formatter [Proc, nil] (Stoplight::Default::FORMATTER)
+      # @param formatter [Proc, nil]
       # @param options [Hash] custom options for the +Sentry#capture_message+ method
       def initialize(sentry, formatter = nil, **options)
         @sentry = sentry
-        @formatter = formatter || Stoplight::Wiring::Default::FORMATTER
+        @formatter = formatter || DEFAULT_FORMATTER
         @options = options
       end
 

--- a/spec/sentry_spec.rb
+++ b/spec/sentry_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "sentry-ruby"
+
+RSpec.describe Sentry do
+  it { expect(Sentry).to be_respond_to("capture_message") }
+end

--- a/stoplight-sentry.gemspec
+++ b/stoplight-sentry.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
     Dir.glob(File.join("lib", "**", "*.rb"))
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "stoplight", ">= 4.0"
+  spec.add_dependency "stoplight", ">= 5.0"
   spec.add_dependency "sentry-ruby", ">= 5"
 end

--- a/stoplight-sentry.gemspec
+++ b/stoplight-sentry.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
     Dir.glob(File.join("lib", "**", "*.rb"))
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "stoplight", ">= 5.0"
+  spec.add_dependency "stoplight"
   spec.add_dependency "sentry-ruby", ">= 5"
 end

--- a/stoplight-sentry.gemspec
+++ b/stoplight-sentry.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
     Dir.glob(File.join("lib", "**", "*.rb"))
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "stoplight"
+  spec.add_dependency "stoplight", ">= 5"
   spec.add_dependency "sentry-ruby", ">= 5"
 end

--- a/stoplight-sentry.gemspec
+++ b/stoplight-sentry.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "stoplight", ">= 4.0"
-  spec.add_dependency "sentry-ruby", ">= 5", "< 6.0"
+  spec.add_dependency "sentry-ruby", ">= 5"
 end


### PR DESCRIPTION
This also makes sense because if we are flexible on the `stoplight` gem (which also in a major version can change the API interface for a Notifier ) we can also even be more flexible for sentry-ruby from which we only use `capture_message` if I'm not mistaken